### PR TITLE
Add support for GPX string

### DIFF
--- a/gpxreplay.d.ts
+++ b/gpxreplay.d.ts
@@ -1,4 +1,4 @@
-declare module 'gpxreplay' {
+declare module '@palleter/gpxreplay' {
 
   interface Point {
     lon: number;

--- a/gpxreplay.d.ts
+++ b/gpxreplay.d.ts
@@ -1,0 +1,32 @@
+declare module 'gpxreplay' {
+
+  interface Point {
+    lon: number;
+    lat: number;
+    elevation: number;
+    fromPrevious: {
+      bearing: number;
+      veolocity: number;
+      time: number;
+      climb: number;
+      distance: number
+    };
+    toCurrent: {
+      time: number;
+      meanVelocity: number;
+      climb: number;
+      distance: number
+    };
+  }
+
+  type WaypointCallback = (point: Point) => void;
+
+  interface GPXReplayOptions {
+    rate: number;
+    loop: boolean;
+    limitWait: number;
+    precision: number;
+  }
+
+  export const playTrack: (trackFile: string, printWaypoint: WaypointCallback, options: GPXReplayOptions) => void;
+}

--- a/gpxreplay.js
+++ b/gpxreplay.js
@@ -5,18 +5,18 @@
  * @version 1.0.0
  */
 
-var gpxParse = require("gpx-parse");
+var gpxParse = require('gpx-parse');
 var LatLon = require('geodesy').LatLonEllipsoidal;
 var fs = require('fs');
 
 var options = {
-  rate : 1,
-  loop : false,
-  limitWait : -1,
-  precision : -1
+  rate: 1,
+  loop: false,
+  limitWait: -1,
+  precision: -1
 };
 
-var precisionIterator = function (obj, stack) {
+var precisionIterator = function(obj, stack) {
   for (var property in obj) {
     if (obj.hasOwnProperty(property)) {
       if (typeof obj[property] == "object") {
@@ -31,9 +31,10 @@ var precisionIterator = function (obj, stack) {
 var sendData = function(data, callback) {
   var len = data.length;
   var delay = 0;
-  data.forEach(function (currentValue, index, array){
-    delay = delay + currentValue.delay; //all timers are created at the same time so add
-    setTimeout(function(x){
+  data.forEach(function(currentValue, index, array) {
+    //all timers are created at the same time so add
+    delay = delay + currentValue.delay;
+    setTimeout(function(x) {
       return function() {
         callback(currentValue.data);
         if (options.loop && index == len - 1) sendData(data, callback); //loop
@@ -53,35 +54,35 @@ var playGPX = function(data, callback) {
   var totalTime = 0;
   var meanVelocity = 0;
   for (var i = 0; i < tlen - 1; i++) { //we always need a next-segment
-    var tp1 = tseg[i], tp2 = tseg[i+1];
+    var tp1 = tseg[i], tp2 = tseg[i + 1];
     var p1 = new LatLon(tp1.lat, tp1.lon);
     var p2 = new LatLon(tp2.lat, tp2.lon);
     var t = Date.parse(tp2.time) - Date.parse(tp1.time);
-    totalTime = totalTime + t/1000;
+    totalTime = totalTime + t / 1000;
     var d = p1.distanceTo(p2);
     var v = 3600 * d / t;
-    meanVelocity = ( meanVelocity + v )/2;
+    meanVelocity = (meanVelocity + v) / 2;
     var b = p1.initialBearingTo(p2);
 
     //if requested, set the max time between waypoints
     //rate divider sets playback speed
-    var delay = ((options.limitWait > 0) ? (t > options.limitWait ? options.limitWait : t) : t)/options.rate;
+    var delay = ((options.limitWait > 0) ? (t > options.limitWait ? options.limitWait : t) : t) / options.rate;
 
-    op = {
-      'data': {
-        'lon': tp2.lon,
-        'lat': tp2.lat,
-        'fromPrevious' :{
-          'bearing': b,
-          'velocity': v,
-          'time': t/1000
+    var op = {
+      data: {
+        lon: tp2.lon,
+        lat: tp2.lat,
+        fromPrevious: {
+          bearing: b,
+          velocity: v,
+          time: t / 1000
         },
-        'toCurrent' : {
-          'time': totalTime,
-          'meanVelocity': meanVelocity
+        toCurrent: {
+          time: totalTime,
+          meanVelocity: meanVelocity
         }
       },
-      'delay': delay
+      delay: delay
     };
 
     //if elevation included in legs, use straight line approximation
@@ -99,7 +100,7 @@ var playGPX = function(data, callback) {
     op.data.toCurrent.distance = totalDistance;
 
     //limit precision
-    if (options.precision >=0){
+    if (options.precision >= 0) {
       precisionIterator(op, '');
     }
     trackData.push(op);
@@ -122,8 +123,8 @@ playTrack = function(file, callback, _options) {
     if (typeof file != 'string') return;
 
     //parse optional args
-    for (var op in _options){
-      if (op in options && typeof(options[op]) === typeof(_options[op])){
+    for (var op in _options) {
+      if (op in options && typeof(options[op]) === typeof(_options[op])) {
         if (typeof(_options[op]) === 'number' && _options[op] < 0) break;
         options[op] = _options[op];
       }

--- a/gpxreplay.js
+++ b/gpxreplay.js
@@ -7,6 +7,7 @@
 
 var gpxParse = require("gpx-parse");
 var LatLon = require('geodesy').LatLonEllipsoidal;
+var fs = require('fs');
 
 var trackData = [];
 var callback = null;
@@ -134,7 +135,14 @@ playTrack = function(file, _callback, _options) {
         options[op] = _options[op];
       }
     }
-    gpxParse.parseGpxFromFile(file, playGPX);
+
+    fs.lstat(file, function(err, stat) {
+      if (stat && stat.isFile()) {
+        gpxParse.parseGpxFromFile(file, playGPX);
+      } else {
+        gpxParse.parseGpx(file, playGPX);
+      }
+    });
 };
 
 if (typeof module != 'undefined' && module.exports) module.exports.playTrack = playTrack;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Output waypoints from a GPX tracklog in real-time",
   "main": "gpxreplay.js",
+  "types": "gpxreplay.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gpxreplay",
+  "name": "@palleter/gpxreplay",
   "version": "1.0.0",
   "description": "Output waypoints from a GPX tracklog in real-time",
   "main": "gpxreplay.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@palleter/gpxreplay",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Output waypoints from a GPX tracklog in real-time",
   "main": "gpxreplay.js",
   "types": "gpxreplay.d.ts",


### PR DESCRIPTION
In addition to play the GPX track directly from file, support GPX file contents as input string as well.

This adds option to read GPX track data from other sources.

Currently, reading data from URL is not supported.
